### PR TITLE
fix /etc/php5/conf.d/* is present

### DIFF
--- a/modules/php/manifests/ini.pp
+++ b/modules/php/manifests/ini.pp
@@ -4,7 +4,7 @@ define php::ini (
     $target   = 'extra.ini',
     $service  = $php::service
 ) {
-  file { "/etc/php5/conf.d/${target}":
+  file { "/etc/php5/apache2/conf.d/${target}":
     ensure  => 'present',
     content => template("php/${template}"),
     require => Package['php'],


### PR DESCRIPTION
I had that error:
err: /Stage[main]//Php::Ini[custom]/File[/etc/php5/conf.d/custom.ini]/ensure: change from absent to present failed: Could not set 'present on ensure: No such file or directory - /etc/php5/conf.d/custom.ini.puppettmp_9262 at /tmp/vagrant-puppet/modules-0/php/manifests/ini.pp:12
err: /Stage[main]//Php::Ini[php]/File[/etc/php5/conf.d/php.ini]/ensure: change from absent to present failed: Could not set 'present on ensure: No such file or directory - /etc/php5/conf.d/php.ini.puppettmp_4907 at /tmp/vagrant-puppet/modules-0/php/manifests/ini.pp:12
